### PR TITLE
Update package.json by adding gatsby-plugin keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/NimblNotes/gatsby-transformer-nimbl.git"
   },
-  "keywords": ["markdown", "gatsby"],
+  "keywords": ["markdown", "gatsby", "gatsby-plugin"],
   "author": "ZaninAndrea",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
## Changes
* Added `gatsby-plugin` keyword to package.json
## Description
Hello. I found that the `package.json` file does not contain the keyword `gatsby-plugin`. This change will [submit the plugin to the Gatsby Plugin Library](https://www.gatsbyjs.org/contributing/submit-to-plugin-library/). You can also go to gatsbyjs/gatsby#14013 for more detailed information. Thanks.